### PR TITLE
[docs] python resource link updated

### DIFF
--- a/developer/google-code-in.rst
+++ b/developer/google-code-in.rst
@@ -212,7 +212,7 @@ raise to the top!
 
 Programming languages and frameworks:
 
-  - `Python <http://www.diveintopython3.net/>`_ (book)
+  - `Python <https://runestone.academy/runestone/static/pythonds/index.html>`_ (book)
   - `Django <https://docs.djangoproject.com/en/1.11/>`_ (official documentation)
   - `Lua <https://www.youtube.com/watch?v=iMacxZQMPXs/>`_ (video tutorial)
   - `Shell <https://www.youtube.com/watch?v=hwrnmQumtPw/>`_ (video tutorial)

--- a/developer/google-summer-of-code.rst
+++ b/developer/google-summer-of-code.rst
@@ -86,7 +86,7 @@ read these resources, it will help you to speed up your raise to the top!
 
 Programming languages and frameworks:
 
-  - `Python <http://www.diveintopython3.net/>`_ (book)
+  - `Python <https://runestone.academy/runestone/static/pythonds/index.html>`_ (book)
   - `Django <https://docs.djangoproject.com/en/1.11/>`_
     (official documentation)
   - `Lua <https://www.youtube.com/watch?v=iMacxZQMPXs/>`_ (video tutorial)


### PR DESCRIPTION
Fixes #79 
Updated the python resource link
from http://www.diveintopython3.net to https://runestone.academy/runestone/static/pythonds/index.html
please review :)