### PR TITLE
[Improvement] Added code to redirect links on new tab

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -5,6 +5,7 @@
 {% block footer %}
 {{ super() }}
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-46086503-11"></script>
+<base target="_blank">
 <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments)};

--- a/developer/contributing.rst
+++ b/developer/contributing.rst
@@ -19,7 +19,7 @@ Look for open issues
 
 Check out the `OpenWISP Contributor's Board
 <https://github.com/orgs/openwisp/projects/3>`_, this is a kanban board
-integrated with github were we place the most important issues we are
+integrated with github where we place the most important issues we are
 working on.
 
 If there's anything you don't understand regarding the


### PR DESCRIPTION
All the links provided on http://openwisp.io/docs/developer/contributing.html redirects to the new page in the same tab which is not convenient for the user.
So, I added code to redirect links on new tab!!