### PR TITLE
[gsoc17] add link to personal blog for the GSOC 2017 project

### DIFF
--- a/general/press.rst
+++ b/general/press.rst
@@ -121,6 +121,7 @@ Blog Posts
 - `Introducing OpenWISP Monitoring: Google Summer of Code 2020
   Project report <https://medium.com/@nepython/openwisp-monitoring-
   gsoc-2020-project-report-332441961629>`_
+- `GSOC 2017: adding AirOS support to netjsonconfig <https://edoput.github.io/openwispgsoc/>`_
 
 Research and publications
 -------------------------


### PR DESCRIPTION
I had to publish a little website explaining the project and what happened as per GSOC 2017 rules.

I decided that a good format was a little blog with one post for each "deadline" and went with that. I think
it's a good documentation of what the process looks like and what student can expect. It references what
work was done, it points to the PR and mailing list threads where we discussed them.

Obviously it's more personal than a press  release but you never know who lands on this `press` page.