### PR TITLE
[docs] Update python style conventions docs #122

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 _build/
 
 .vscode/
+
+venv

--- a/developer/contributing.rst
+++ b/developer/contributing.rst
@@ -159,15 +159,16 @@ OpenWISP follows `PEP 8 -- Style Guide for Python Code
 automatic tools to check code conventions:
 
 - `flake8 <http://flake8.pycqa.org/en/latest/>`_ is used to
-  automatically check the quality of the python code being committed,
-  each python repo has either a ``flake8`` configuration defined in
-  ``setup.cfg`` or a ``runflake8`` script that you can launch with
-  ``flake8`` or ``./runflake8`` respectively.
+  automatically check the quality of the python code being committed.
+
 - `isort <http://isort.readthedocs.io/en/latest/>`_ is used in order
-  to sort import in a specifc predictable order; each python repo has
-  a ``runisort`` script that you can launch with ``./runisort``
-- Lastly, `black <https://black.readthedocs.io/en/stable/>`_ is used to
+  to sort import in a specifc predictable order; 
+
+- `black <https://black.readthedocs.io/en/stable/>`_ is used to
   automatically format the code according to our conventions.
+
+- Each python repo has a ``run-qa-checks`` script that you can run with ``./run-qa-checks``  
+  which will automatically launch ``flake8``, ``issort`` and ``black``.
 
 For your convenience, we provide the following scripts available in the
 `openwisp-utils <https://github.com/openwisp/openwisp-utils>`_ repository:


### PR DESCRIPTION
modified instructions to launching issort and flake8 with run-qa-check instead of runflake8 and issort

Add venv in the gitignore

Fixes #122