### PR TITLE
[fix] Ensure we're switching to a branch in build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -285,10 +285,15 @@ def clone_or_update_repo(name, branch, dir_name, owner="openwisp", dest=None):
 
     if os.path.exists(clone_path):
         print(f"Repository '{name}' already exists. Updating...")
+        subprocess.run(
+            ["git", "fetch", "origin", f"refs/heads/{branch}:refs/heads/{branch}"],
+            cwd=clone_path,
+            check=True,
+        )
         # "-c advice.detachedHead=false" is used to suppress the warning
         # about being in a detached HEAD state when checking out tags.
         subprocess.run(
-            ["git", "-c", "advice.detachedHead=false", "checkout", branch],
+            ["git", "-c", "advice.detachedHead=false", "checkout", f"refs/heads/{branch}"],
             cwd=clone_path,
             check=True,
         )


### PR DESCRIPTION
We have a tags and branches with the same name (eg: 25.10), this patch ensures we're always switching to branches in `build.py`.