### PR TITLE
[fix] Update index.jinja2 for relative url path

### DIFF
--- a/_static/index.jinja2
+++ b/_static/index.jinja2
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="refresh" content="0; URL='{{ docs_root }}/{{ stable_version }}/index.html'" />
+<meta http-equiv="refresh" content="0; URL='{% if docs_root %}{{ docs_root }}/{% endif %}{{ stable_version }}/index.html'" />
 </head>
 <body>
 </body>


### PR DESCRIPTION
This resolves #281 
After this change the produced index,html should point to the correct <version>/index.html, even if docs_root is not defined.